### PR TITLE
Fixed namespace in TransferFunction (multiple definition under Win32), Disable testing in Capsules::executeLoad for Win32 (undefined drand48()), add calling _putenv_s() instead of setenv for Win32

### DIFF
--- a/hayStack/TransferFunction.h
+++ b/hayStack/TransferFunction.h
@@ -28,7 +28,7 @@ namespace hs {
   struct TransferFunction {
     void load(const std::string &fileName);
     
-    std::vector<vec4f> colorMap = { vec4f(1.f), vec4f(1.f) };
+    std::vector<mini::common::vec4f> colorMap = { mini::common::vec4f(1.f), mini::common::vec4f(1.f) };
     range1f domain = { 0.f, 0.f };
     float   baseDensity = 1.f;
   };

--- a/viewer/content/Capsules.cpp
+++ b/viewer/content/Capsules.cpp
@@ -69,7 +69,7 @@ namespace hs {
     void   Capsules::executeLoad(DataRank &dataGroup, bool verbose) 
     {
       if (data.where == "<test>") {
-#if 1
+#ifndef _WIN32
         float rr = .01f;
         
         for (int a=0;a<1000;a++) {

--- a/viewer/main.cpp
+++ b/viewer/main.cpp
@@ -199,7 +199,11 @@ namespace hs {
         if (key == '9' || key == '0')
           ratio = (ratio - 1.f) * 0.1f + 1.f; 
         float fl = (flc == nullptr) ? 1.f : std::stof(flc) * ratio;
+#ifdef _WIN32
+        _putenv_s("BARNEY_FOCAL_LENGTH", std::to_string(fl).c_str());
+#else        
         setenv("BARNEY_FOCAL_LENGTH", std::to_string(fl).c_str(), 1);
+#endif        
         std::cout << "Focal length is set to: " << fl << '\n';
         renderer->resetAccumulation();
         break;
@@ -211,7 +215,11 @@ namespace hs {
         if (key == '[' || key == ']')
           ratio = (ratio - 1.f) * 0.1f + 1.f; 
         float lr = (lrc == nullptr) ? 1.f : std::stof(lrc) * ratio;
+#ifdef _WIN32
+        _putenv_s("BARNEY_LENS_RADIUS", std::to_string(lr).c_str());
+#else        
         setenv("BARNEY_LENS_RADIUS", std::to_string(lr).c_str(), 1);
+#endif        
         std::cout << "Lens radius is set to: " << lr << '\n';
         renderer->resetAccumulation();
         break;


### PR DESCRIPTION
Fixed namespace in TransferFunction (multiple definition under Win32), Disable testing in Capsules::executeLoad for Win32 (undefined drand48()), add calling _putenv_s() instead of setenv for Win32